### PR TITLE
Added support for specifying multiple loadbalancer IPs

### DIFF
--- a/playbooks/add-ons.yaml
+++ b/playbooks/add-ons.yaml
@@ -174,30 +174,44 @@
 
    - name: Local IP
      set_fact:
-       load_balancer_ip: "{% if loadbalancer_ip == '' %}{{ network.stdout_lines[0] }}/32{%elif loadbalancer_ip != '' %}{{ loadbalancer_ip }}{% endif %}"
+       load_balancer_ips: "{{ loadbalancer_ips if loadbalancer_ips | length > 0 else [network.stdout_lines[0] + '/32'] }}"
+     when: loadbalancer == true
 
-   - name: Apply Layer2 Config for MetalLB
+   - name: Generate MetalLB IP Pool template
+     when: loadbalancer == true
+     copy:
+       src: "{{lookup('pipe', 'pwd')}}/files/ipaddresspool.yaml"
+       dest: "{{ ansible_user_dir }}/ipaddresspool.yaml.j2"
+     retries: 5
+     delay: 5
+     register: generate_ip_pool
+     until: generate_ip_pool is succeeded
+
+   - name: Copy MetalLB L2Advertisement configuration
+     when: loadbalancer == true
+     copy:
+       src: "{{lookup('pipe', 'pwd')}}/files/l2advertisement.yaml"
+       dest: "{{ ansible_user_dir }}/l2advertisement.yaml"
+     retries: 5
+     delay: 5
+     register: copy_l2_adv
+     until: copy_l2_adv is succeeded
+
+   - name: Create final MetalLB IP Pool configuration
+     when: loadbalancer == true
+     ansible.builtin.template:
+       src: "{{ ansible_user_dir }}/ipaddresspool.yaml.j2"
+       dest: "{{ ansible_user_dir }}/ipaddresspool.yaml"
+     retries: 5
+     delay: 5
+     register: create_ip_pool
+     until: create_ip_pool is succeeded
+
+   - name: Apply MetalLB Configuration
      when: loadbalancer == true
      shell: |
-       kubectl apply -f - <<EOF
-       apiVersion: metallb.io/v1beta1
-       kind: IPAddressPool
-       metadata:
-         name: first-pool
-         namespace: metallb-system
-       spec:
-         addresses:
-         - {{  load_balancer_ip }}
-       ---
-       apiVersion: metallb.io/v1beta1
-       kind: L2Advertisement
-       metadata:
-         name: example
-         namespace: metallb-system
-       spec:
-         ipAddressPools:
-         - first-pool
-       EOF
+       kubectl apply -f {{ ansible_user_dir }}/ipaddresspool.yaml
+       kubectl apply -f {{ ansible_user_dir }}/l2advertisement.yaml
      retries: 5
      delay: 5
      register: apply_metallb_config

--- a/playbooks/cns_values.yaml
+++ b/playbooks/cns_values.yaml
@@ -108,8 +108,8 @@ kserve: no
 
 # Install MetalLB
 loadbalancer: no
-# Example input loadbalancer_ip: "10.78.17.85/32"
-loadbalancer_ip: ""
+# Example input loadbalancer_ips: ["10.78.17.85/32","10.78.17.86/32"]
+loadbalancer_ips: []
 
 ## Cloud Native Stack Validation
 cns_validation: no

--- a/playbooks/cns_values_14.0.yaml
+++ b/playbooks/cns_values_14.0.yaml
@@ -108,8 +108,8 @@ kserve: no
 
 # Install MetalLB
 loadbalancer: no
-# Example input loadbalancer_ip: "10.117.20.50/32", it could be node/host IP
-loadbalancer_ip: ""
+# Example input loadbalancer_ips: ["10.78.17.85/32","10.78.17.86/32"]
+loadbalancer_ips: []
 
 ## Cloud Native Stack Validation
 cns_validation: no

--- a/playbooks/cns_values_14.1.yaml
+++ b/playbooks/cns_values_14.1.yaml
@@ -108,8 +108,8 @@ kserve: no
 
 # Install MetalLB
 loadbalancer: no
-# Example input loadbalancer_ip: "10.78.17.85/32"
-loadbalancer_ip: ""
+# Example input loadbalancer_ips: ["10.78.17.85/32","10.78.17.86/32"]
+loadbalancer_ips: []
 
 ## Cloud Native Stack Validation
 cns_validation: no

--- a/playbooks/cns_values_14.2.yaml
+++ b/playbooks/cns_values_14.2.yaml
@@ -108,8 +108,8 @@ kserve: no
 
 # Install MetalLB
 loadbalancer: no
-# Example input loadbalancer_ip: "10.78.17.85/32"
-loadbalancer_ip: ""
+# Example input loadbalancer_ips: ["10.78.17.85/32","10.78.17.86/32"]
+loadbalancer_ips: []
 
 ## Cloud Native Stack Validation
 cns_validation: no

--- a/playbooks/cns_values_15.0.yaml
+++ b/playbooks/cns_values_15.0.yaml
@@ -108,8 +108,8 @@ kserve: no
 
 # Install MetalLB
 loadbalancer: no
-# Example input loadbalancer_ip: "10.78.17.85/32"
-loadbalancer_ip: ""
+# Example input loadbalancer_ips: ["10.78.17.85/32","10.78.17.86/32"]
+loadbalancer_ips: []
 
 ## Cloud Native Stack Validation
 cns_validation: no

--- a/playbooks/cns_values_15.1.yaml
+++ b/playbooks/cns_values_15.1.yaml
@@ -108,8 +108,8 @@ kserve: no
 
 # Install MetalLB
 loadbalancer: no
-# Example input loadbalancer_ip: "10.78.17.85/32"
-loadbalancer_ip: ""
+# Example input loadbalancer_ips: ["10.78.17.85/32","10.78.17.86/32"]
+loadbalancer_ips: []
 
 ## Cloud Native Stack Validation
 cns_validation: no

--- a/playbooks/cns_values_16.0.yaml
+++ b/playbooks/cns_values_16.0.yaml
@@ -108,8 +108,8 @@ kserve: no
 
 # Install MetalLB
 loadbalancer: no
-# Example input loadbalancer_ip: "10.78.17.85/32"
-loadbalancer_ip: ""
+# Example input loadbalancer_ips: ["10.78.17.85/32","10.78.17.86/32"]
+loadbalancer_ips: []
 
 ## Cloud Native Stack Validation
 cns_validation: no

--- a/playbooks/files/ipaddresspool.yaml
+++ b/playbooks/files/ipaddresspool.yaml
@@ -1,0 +1,10 @@
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: default-pool
+  namespace: metallb-system
+spec:
+  addresses:
+{% for ip in load_balancer_ips %}
+  - {{ ip }}
+{% endfor %}

--- a/playbooks/files/l2advertisement.yaml
+++ b/playbooks/files/l2advertisement.yaml
@@ -1,0 +1,8 @@
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: metallb-l2-advertisement
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+  - default-pool


### PR DESCRIPTION
**What this PR does / why we need it?**

Currently, we can only specify a single load balancer IP. In some cases, users may need to define multiple load balancer IPs, this PR updates the configuration to support that


**Changes**

- Changed the `loadbalancer_ip` variable type from string to a list, so users can now provide multiple IPs instead of just one
- Added `ipaddresspool.yaml` and `l2advertisement.yaml` manifests to allow users to modify them for custom configurations if needed (https://metallb.universe.tf/configuration/_advanced_ipaddresspool_configuration/)