### PR TITLE
feat: add configurable NFS storage path

### DIFF
--- a/playbooks/add-ons.yaml
+++ b/playbooks/add-ons.yaml
@@ -55,9 +55,9 @@
      block:
        - name: Setup Mounts for NFS
          shell: |
-           mkdir -p /data/nfs
-           chown nobody:nogroup /data/nfs
-           chmod 2770 /data/nfs
+           mkdir -p {{ nfs_path | default('/data/nfs') }}
+           chown nobody:nogroup {{ nfs_path | default('/data/nfs') }}
+           chmod 2770 {{ nfs_path | default('/data/nfs') }}
          retries: 5
          delay: 5
          register: setup_nfs_mounts
@@ -67,7 +67,7 @@
          lineinfile:
            path: /etc/exports
            insertafter: EOF
-           line: "/data/nfs  *(rw,sync,no_subtree_check,no_root_squash,insecure)"
+           line: "{{ nfs_path | default('/data/nfs') }}  *(rw,sync,no_subtree_check,no_root_squash,insecure)"
          retries: 5
          delay: 5
          register: update_nfs_exports
@@ -109,7 +109,7 @@
      shell: |
        helm repo add nfs-subdir-external-provisioner https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner --force-update
        helm repo update
-       helm install --version {{ nfs_provisioner }} nfs-subdir-external-provisioner nfs-subdir-external-provisioner/nfs-subdir-external-provisioner --set nfs.server={{ ansible_default_ipv4.address }} --set nfs.path=/data/nfs --set storageClass.archiveOnDelete=false --create-namespace --namespace nfs-client
+       helm install --version {{ nfs_provisioner }} nfs-subdir-external-provisioner nfs-subdir-external-provisioner/nfs-subdir-external-provisioner --set nfs.server={{ ansible_default_ipv4.address }} --set nfs.path={{ nfs_path | default('/data/nfs') }} --set storageClass.archiveOnDelete=false --create-namespace --namespace nfs-client
        sleep 10
        kubectl patch storageclass nfs-client -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
      retries: 5

--- a/playbooks/cns_values_14.0.yaml
+++ b/playbooks/cns_values_14.0.yaml
@@ -99,6 +99,8 @@ lws: no
 
 # Local Path Provisioner and NFS Provisoner as Storage option
 storage: no
+# NFS storage path
+nfs_path: "/data/nfs"
 
 # Monitoring Stack Prometheus/Grafana with GPU Metrics and Elastic Logging stack
 monitoring: no

--- a/playbooks/cns_values_14.1.yaml
+++ b/playbooks/cns_values_14.1.yaml
@@ -99,6 +99,8 @@ lws: no
 
 # Local Path Provisioner and NFS Provisoner as Storage option
 storage: no
+# NFS storage path
+nfs_path: "/data/nfs"
 
 # Monitoring Stack Prometheus/Grafana with GPU Metrics and Elastic Logging stack
 monitoring: no

--- a/playbooks/cns_values_14.2.yaml
+++ b/playbooks/cns_values_14.2.yaml
@@ -99,6 +99,8 @@ lws: no
 
 # Local Path Provisioner and NFS Provisoner as Storage option
 storage: no
+# NFS storage path
+nfs_path: "/data/nfs"
 
 # Monitoring Stack Prometheus/Grafana with GPU Metrics and Elastic Logging stack
 monitoring: no

--- a/playbooks/cns_values_15.0.yaml
+++ b/playbooks/cns_values_15.0.yaml
@@ -99,6 +99,8 @@ lws: no
 
 # Local Path Provisioner and NFS Provisoner as Storage option
 storage: no
+# NFS storage path
+nfs_path: "/data/nfs"
 
 # Monitoring Stack Prometheus/Grafana with GPU Metrics and Elastic Logging stack
 monitoring: no

--- a/playbooks/cns_values_15.1.yaml
+++ b/playbooks/cns_values_15.1.yaml
@@ -99,6 +99,8 @@ lws: no
 
 # Local Path Provisioner and NFS Provisoner as Storage option
 storage: no
+# NFS storage path
+nfs_path: "/data/nfs"
 
 # Monitoring Stack Prometheus/Grafana with GPU Metrics and Elastic Logging stack
 monitoring: no

--- a/playbooks/cns_values_16.0.yaml
+++ b/playbooks/cns_values_16.0.yaml
@@ -99,6 +99,8 @@ lws: no
 
 # Local Path Provisioner and NFS Provisoner as Storage option
 storage: no
+# NFS storage path
+nfs_path: "/data/nfs"
 
 # Monitoring Stack Prometheus/Grafana with GPU Metrics and Elastic Logging stack
 monitoring: no


### PR DESCRIPTION
- Add nfs_path variable to version config templates (14.x, 15.x, 16.0)
- Use Jinja2 default filter in add-ons.yaml for backward compatibility
- Default path remains /data/nfs

Users can now customize NFS storage path by setting nfs_path in cns_values.yaml"