### PR TITLE
Fix confidential computing GPU Operator deployment

### DIFF
--- a/playbooks/cns-installation.yaml
+++ b/playbooks/cns-installation.yaml
@@ -19,15 +19,6 @@
         loadbalancer: "{{ loadbalancer }}"
         install_k8s: "{{ install_k8s}}"
 
-    - name: Use host NVIDIA driver on Ubuntu 26.04
-      when:
-        - ansible_facts['distribution'] == 'Ubuntu'
-        - ansible_facts['distribution_version'] == '26.04'
-        - enable_gpu_operator | bool
-        - not (cns_nvidia_driver | bool)
-      set_fact:
-        cns_nvidia_driver: true
-
     # Print a warning (do NOT fail) when the host OS doesn't match the expected
     # Ubuntu release for the chosen cns_version. CNS 18.0 / 19.0 are validated on
     # Ubuntu 24.04 / 26.04; CNS 16.x / 17.x are validated on Ubuntu 22.04 / 24.04.

--- a/playbooks/operators-install.yaml
+++ b/playbooks/operators-install.yaml
@@ -434,6 +434,7 @@
              nvidia/gpu-operator \
              --set sandboxWorkloads.enabled=true \
              --set sandboxWorkloads.mode=kata \
+             --set sandboxWorkloads.defaultWorkload=vm-passthrough \
              --set nfd.enabled=true \
              --set nfd.nodefeaturerules=true \
              --version=v{{ gpu_operator_version }}


### PR DESCRIPTION
## Summary
- remove the Ubuntu 26.04 override that forced host-driver mode and skipped the Confidential Computing GPU Operator path
- configure Kata confidential workloads to default to GPU passthrough

## Root cause
The Ubuntu-specific override set `cns_nvidia_driver: true`, which made the Confidential Computing GPU Operator task ineligible. Without a passthrough default, the CC/Kata deployment also retained the chart default of `container`.

## Validation
- `ansible-playbook -i hosts operators-install.yaml --syntax-check`