### PR TITLE
Improve confidential computing installation and cleanup

### DIFF
--- a/playbooks/ansible.cfg
+++ b/playbooks/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+interpreter_python = auto_silent

--- a/playbooks/cns-installation.yaml
+++ b/playbooks/cns-installation.yaml
@@ -154,7 +154,6 @@
     # Confidential Computing — Intel TDX host setup (Step 3)
     # Auto-selected when CPU is GenuineIntel.
     # AMD SNP is handled by the conf_compu_snp_install.sh block above.
-    # Ref: https://nvidia.atlassian.net/wiki/spaces/~fguillier/pages/3331881069
     # ============================================================
     - name: TDX | Check whether nohibernate is in current kernel cmdline
       when: confidential_computing == true and cpu_vendor.stdout == 'GenuineIntel'
@@ -335,7 +334,6 @@
     # Confidential Computing — post-reboot validation
     # Step 3: Verify TDX module initialized (Intel only)
     # Step 4: Verify IOMMU groups present (any CC vendor)
-    # Ref Step 4: https://nvidia.atlassian.net/wiki/spaces/~fguillier/pages/3331881168
     # Warnings only — do not block CNS install.
     # ============================================================
     - name: "TDX | Validate 'virt/tdx: module initialized' in dmesg"
@@ -369,6 +367,35 @@
       when: confidential_computing == true and cpu_vendor.stdout == 'GenuineIntel' and tdx_param_check.stdout != 'Y'
       debug:
         msg: "WARNING: /sys/module/kvm_intel/parameters/tdx is '{{ tdx_param_check.stdout | default('') }}' (expected 'Y'). TDX not active for KVM guests."
+
+    - name: CoCo | Detect Hopper HGX topology for PPCIE
+      when: confidential_computing == true
+      shell: |
+        lspci -nn -d 10de: | awk '
+          /0302/ {
+            gpu_count++
+            if (/(H100|H200).*SXM/) hopper_sxm_count++
+          }
+          /0680/ { nvswitch_count++ }
+          END {
+            printf "GPUs:%d NVSwitch:%d HopperSXM:%d\\n", \
+              gpu_count, nvswitch_count, hopper_sxm_count
+            if (gpu_count == 8 && nvswitch_count >= 4 && hopper_sxm_count == gpu_count) print "HGX Hopper"
+            else print "Not Hopper HGX"
+          }'
+      register: coco_hgx_topology
+      changed_when: false
+      failed_when: false
+
+    - name: CoCo | Record Hopper HGX PPCIE eligibility
+      when: confidential_computing == true
+      set_fact:
+        coco_hgx_hopper: "{{ 'HGX Hopper' in coco_hgx_topology.stdout }}"
+
+    - name: CoCo | Report Hopper HGX PPCIE eligibility
+      when: confidential_computing == true
+      debug:
+        msg: "{{ coco_hgx_topology.stdout | default('Hopper HGX topology could not be detected') }}"
 
     - name: IOMMU | Count IOMMU groups (Step 4)
       when: confidential_computing == true

--- a/playbooks/cns-uninstall.yaml
+++ b/playbooks/cns-uninstall.yaml
@@ -106,7 +106,6 @@
    - name: Uninstall Helm Charts on NVIDIA Cloud Native Stack
      ignore_errors: true
      when:  release != 'tegra' and microk8s == false
-     async: 360
      shell: |
        count=$(helm ls -A | egrep 'gpu-operator|network-operator|kata-deploy' | grep -v NAME | wc -l)
        if [[ $count > 0 ]]; then

--- a/playbooks/operators-install.yaml
+++ b/playbooks/operators-install.yaml
@@ -353,11 +353,7 @@
    # The install steps below are vendor-agnostic. The vendor only
    # matters at workload time (runtimeClassName), handled in the
    # Step 11 validation block. Note: microk8s is NOT supported (per Step 7).
-   # Refs:
-   #   Step 7  https://nvidia.atlassian.net/wiki/spaces/~fguillier/pages/3331881224
-   #   Step 8  https://nvidia.atlassian.net/wiki/spaces/~fguillier/pages/3331881337
-   #   Step 9  cluster-wide CC mode is ON by default — no patch needed
-   #   Step 10 https://nvidia.atlassian.net/wiki/spaces/~fguillier/pages/3336434268
+   # Cluster-wide CC mode is on by default; no patch is needed.
    # ============================================================
    - name: Install Kata + GPU Operator for Confidential Computing (Intel TDX / AMD SNP)
      when: "confidential_computing == true and enable_gpu_operator == true and microk8s == false and enable_mig == false and enable_vgpu == false and enable_rdma == false and enable_gds == false and enable_secure_boot == false and cns_nvidia_driver == false"
@@ -378,6 +374,36 @@
          when: coco_cpu_vendor.stdout != 'GenuineIntel' and coco_cpu_vendor.stdout != 'AuthenticAMD'
          debug:
            msg: "WARNING: CPU vendor '{{ coco_cpu_vendor.stdout }}' is not supported for CoCo. Expected GenuineIntel (TDX) or AuthenticAMD (SNP). Continuing install but CoCo workloads will not run."
+
+       - name: CoCo | Enable PPCIE mode on detected Hopper HGX nodes
+         when: hostvars[item].coco_hgx_hopper | default(false) | bool
+         shell: |
+           kube_node_name="$(
+             kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{" "}{range .status.addresses[*]}{.type}{"="}{.address}{" "}{end}{"\n"}{end}' | \
+               awk -v hostname="{{ hostvars[item].ansible_facts.get('hostname', '') }}" \
+                   -v ip="{{ hostvars[item].ansible_facts.get('default_ipv4', {}).get('address', '') }}" \
+                   '{
+                     for (i = 2; i <= NF; i++) {
+                       split($i, address, "=")
+                       if ((address[1] == "Hostname" && address[2] == hostname) || (address[1] == "InternalIP" && address[2] == ip)) {
+                         print $1
+                         exit
+                       }
+                     }
+                   }'
+           )"
+           test -n "$kube_node_name" || {
+             echo "Unable to map Ansible host '{{ item }}' to a Kubernetes node." >&2
+             exit 1
+           }
+           kubectl label node "$kube_node_name" nvidia.com/cc.mode=ppcie --overwrite
+         loop: "{{ groups['all'] }}"
+         loop_control:
+           label: "{{ hostvars[item].ansible_facts.get('hostname', item) }}"
+         register: label_coco_ppcie
+         retries: 5
+         delay: 5
+         until: label_coco_ppcie is succeeded
 
        - name: CoCo | Label nodes with vm-passthrough (Step 7)
          shell: kubectl label nodes --all nvidia.com/gpu.workload.config=vm-passthrough --overwrite
@@ -478,7 +504,6 @@
 
    # ============================================================
    # Confidential Computing — Validation (Step 11)
-   # Ref: https://nvidia.atlassian.net/wiki/spaces/~fguillier/pages/3331971821
    # Vendor-aware: TDX -> kata-qemu-nvidia-gpu-tdx, SNP -> kata-qemu-nvidia-gpu-snp
    # Gated on cns_validation == true. Failures soft — debug message only.
    # ============================================================

--- a/playbooks/readme.md
+++ b/playbooks/readme.md
@@ -844,6 +844,8 @@ What this does:
 - Installs Kata via `helm install kata-deploy oci://ghcr.io/kata-containers/kata-deploy-charts/kata-deploy --version 3.29.0`
 - Installs GPU Operator: `--set sandboxWorkloads.enabled=true --set sandboxWorkloads.mode=kata --set nfd.enabled=true --set nfd.nodefeaturerules=true --version=v26.3.1`
 - Configures kubelet `runtimeRequestTimeout: 1200s` and feature gates `KubeletPodResourcesGet=true`, `RuntimeClassInImageCriApi=true`
+- Detects Hopper HGX nodes with 8 H100/H200 SXM GPUs and at least 4 NVSwitches, then sets
+  `nvidia.com/cc.mode=ppcie` before GPU Operator installation for multi-GPU passthrough
 - Labels the node `nvidia.com/gpu.workload.config=vm-passthrough` and the vendor-specific NFD label (`amd.feature.node.kubernetes.io/snp=true` or `intel.feature.node.kubernetes.io/tdx=true`) so kata runtime classes schedule
 
 > If Intel TDX triggers a reboot mid-install, just re-run `bash setup.sh install cc` after the host comes back. Tasks are idempotent; the second run picks up where the first left off.
@@ -984,5 +986,4 @@ The Ansible NVIDIA Cloud Native Stack uninstall playbook will do the following:
 ### Getting Help
 
 Please [open an issue on the GitHub project](https://github.com/NVIDIA/cloud-native-stack/issues) for any questions. Your feedback is appreciated.
-
 

--- a/playbooks/setup.sh
+++ b/playbooks/setup.sh
@@ -85,9 +85,30 @@ if [[ -r /etc/os-release ]]; then
   fi
 fi
 
+existing_confidential_computing=""
+if [[ -r cns_values.yaml ]]; then
+	existing_confidential_computing=$(awk -F': *' '/^confidential_computing:/ {print $2; exit}' cns_values.yaml | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')
+fi
+
 version=$(cat cns_version.yaml | awk -F':' '{print $2}' | head -n1 | tr -d ' ' | tr -d '\n\r')
 cp cns_values_$version.yaml cns_values.yaml
+selected_confidential_computing=$(awk -F': *' '/^confidential_computing:/ {print $2; exit}' cns_values.yaml | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')
+if [[ "$1" == "uninstall" && ( "$existing_confidential_computing" == "yes" || "$existing_confidential_computing" == "true" ) ]]; then
+	sed -i 's/^confidential_computing:.*/confidential_computing: yes/' cns_values.yaml
+	echo "Preserving confidential_computing: yes for uninstall cleanup."
+fi
 #sed -i "1s/^/cns_version: $version\n/" cns_values.yaml
+
+if [[ "$1" == "install" && "${2:-}" != "cc" && "$selected_confidential_computing" != "yes" && "$selected_confidential_computing" != "true" && -r /etc/os-release ]]; then
+	. /etc/os-release
+	if [[ "${ID:-}" == "ubuntu" && "${VERSION_ID:-}" == "26.04" ]]; then
+		echo "ERROR: Standard CNS installation is not supported on Ubuntu 26.04." >&2
+		echo "CNS supports Ubuntu 26.04 only for Confidential Computing." >&2
+		echo "Run: bash setup.sh install cc" >&2
+		echo "Use Ubuntu 24.04 for the standard GPU Operator installation path." >&2
+		exit 2
+	fi
+fi
 
 # Ansible Install
 


### PR DESCRIPTION
## Summary

- detect supported Hopper HGX topology during Confidential Computing installation and label eligible nodes for PPCIE mode before GPU Operator deployment
- preserve Confidential Computing cleanup behavior during uninstall and prevent unsupported standard Ubuntu 26.04 installs
- silence Ansible interpreter discovery noise and remove internal documentation links

## Validation

- `bash -n playbooks/setup.sh`
- Ansible syntax checks for installation, operator, and uninstall playbooks
- live Ubuntu 26.04 Hopper HGX Confidential Computing installation completed with `failed=0`
- verified `nvidia.com/cc.mode=ppcie` on the eligible node