### PR TITLE
Update Kata Deploy to 3.32.0

### DIFF
--- a/playbooks/operators-install.yaml
+++ b/playbooks/operators-install.yaml
@@ -437,7 +437,7 @@
              --namespace kata-system --create-namespace \
              --set nfd.enabled=false \
              --wait --timeout 10m \
-             --version 3.29.0
+             --version 3.32.0
          retries: 3
          delay: 10
          register: install_kata_deploy

--- a/playbooks/prerequisites.yaml
+++ b/playbooks/prerequisites.yaml
@@ -554,8 +554,8 @@
           until: enable_systemd_cgroups is succeeded
 
         # Force config schema down to version=3 ONLY when kata-deploy is in play.
-        # containerd 2.3 emits version=4 by default; kata-deploy 3.29.0 only knows v2/v3
-        # schemas and errors "Containerd config has no version=2 or version=3" when
+        # CNS uses a v3 config for its kata-deploy and nydus setup. containerd 2.3 emits
+        # version=4 by default and errors "Containerd config has no version=2 or version=3" when
         # adding the nydus snapshotter. The plugin sections are already in v3 layout
         # (io.containerd.cri.v1.images), so flipping just the header is safe.
         # On non-CC installs leaving v4 alone matters: nvidia-container-toolkit-daemonset

--- a/playbooks/readme.md
+++ b/playbooks/readme.md
@@ -841,7 +841,7 @@ What this does:
 - Intel: ensures `nohibernate` in GRUB and `kvm_intel tdx=1` module option, then reboots once for TDX to initialize
 - AMD: probes `kvm_amd.sev_snp` — on modern kernels, skips the legacy AMDSEV custom-kernel build
 - Installs k8s, containerd, helm
-- Installs Kata via `helm install kata-deploy oci://ghcr.io/kata-containers/kata-deploy-charts/kata-deploy --version 3.29.0`
+- Installs Kata via `helm install kata-deploy oci://ghcr.io/kata-containers/kata-deploy-charts/kata-deploy --version 3.32.0`
 - Installs GPU Operator: `--set sandboxWorkloads.enabled=true --set sandboxWorkloads.mode=kata --set nfd.enabled=true --set nfd.nodefeaturerules=true --version=v26.3.1`
 - Configures kubelet `runtimeRequestTimeout: 1200s` and feature gates `KubeletPodResourcesGet=true`, `RuntimeClassInImageCriApi=true`
 - Detects Hopper HGX nodes with 8 H100/H200 SXM GPUs and at least 4 NVSwitches, then sets
@@ -986,4 +986,3 @@ The Ansible NVIDIA Cloud Native Stack uninstall playbook will do the following:
 ### Getting Help
 
 Please [open an issue on the GitHub project](https://github.com/NVIDIA/cloud-native-stack/issues) for any questions. Your feedback is appreciated.
-


### PR DESCRIPTION
## Summary

- update the CNS Confidential Computing Kata Deploy chart from `3.29.0` to `3.32.0`
- update the CoCo installation documentation and remove the stale version-specific compatibility wording

## Why

Kata Deploy `3.29.0` carries the 590 driver and QEMU 10.2.0, which does not support the B300 TDX GPU passthrough scenario. Kata Deploy `3.32.0` includes the required 595 driver and QEMU 11.0.0. The validated B300 PyTorch workload reached `Running` with `3.32.0`.

## Validation

- resolved `oci://ghcr.io/kata-containers/kata-deploy-charts/kata-deploy` at version `3.32.0`
- Ansible syntax checks for `playbooks/prerequisites.yaml` and `playbooks/operators-install.yaml`
- confirmed no `3.29.0` references remain in the checkout